### PR TITLE
suspend/resume: fix touchscreen and i2c kernel spew

### DIFF
--- a/lib/systemd/system-sleep/atmel_mxt_ts
+++ b/lib/systemd/system-sleep/atmel_mxt_ts
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+MODULE=atmel_mxt_ts
+LOADED="/sys/module/${MODULE}"
+SUSPENDED="/run/${MODULE}.suspended"
+
+case $1/$2 in
+    pre/*)
+        [[ -e "${LOADED}" ]] || exit 0
+        modprobe -r "${MODULE}"
+        touch "${SUSPENDED}"
+        ;;
+    post/*)
+        [[ -e "${SUSPENDED}" ]] || exit 0
+        modprobe "${MODULE}"
+        rm "${SUSPENDED}"
+        ;;
+esac
+exit 0


### PR DESCRIPTION
This addresses https://github.com/GalliumOS/galliumos-distro/issues/511

Bad suspend behavior was observed on Caroline w/ beta and all updates.

This should fix the issue for all models using atmel_mxt_ts ("Atmel maXTouch Touchpad").